### PR TITLE
add prom-operator crd to get servicemonitor crd

### DIFF
--- a/.test-dependencies.yaml
+++ b/.test-dependencies.yaml
@@ -97,7 +97,7 @@ components:
   # Cluster Connect Gateway
   - name: cluster-connect-gateway
     skip-component: false
-    skip-local-build: false
+    skip-local-build: true
     pre-install-commands: []
     helm-repo:
       - url: "oci://registry-rs.edgeorchestration.intel.com"
@@ -114,7 +114,7 @@ components:
         overrides: ""
     git-repo:
       url: https://github.com/open-edge-platform/cluster-connect-gateway.git
-      version: metrics
+      version: main
     make-directory: ""
     make-variables:
       - KIND_CLUSTER=kind


### PR DESCRIPTION
Intel infra provider and cluster connect gateway deploys ServiceMonitor in their chart
Added service monitor CRD (which is a part of prometheus-operator)

Alternate way was to disable metrics on helm install. Although I think its better to keep them and add some tests later for metrics export.