### PR TITLE
test: Improve cluster tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ functional-test: bootstrap ## Runs cluster orch functional tests
 template-api-test-smoke: ## Runs cluster orch template API tests
 	PATH=${ENV_PATH} mage test:ClusterOrchTemplateApiSmoke
 
+.PHONY: template-api-test-nightly
+template-api-test-nightly: ## Runs cluster orch template API Nightly tests
+	PATH=${ENV_PATH} mage test:ClusterOrchTemplateApiNightly
+
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)

--- a/mage/Magefile.go
+++ b/mage/Magefile.go
@@ -64,6 +64,11 @@ func (t Test) ClusterOrchTemplateApiSmoke() error {
 	return t.clusterOrchTemplateApiSmoke()
 }
 
+// ClusterOrchTemplateApiNightly Runs template api test
+func (t Test) ClusterOrchTemplateApiNightly() error {
+	return t.clusterOrchTemplateApiNightly()
+}
+
 ////// Lint specific targets
 
 type Lint mg.Namespace

--- a/mage/test.go
+++ b/mage/test.go
@@ -121,6 +121,19 @@ func (Test) clusterOrchTemplateApiSmoke() error {
 	)
 }
 
+// Test Runs cluster orch template api nightly test
+func (Test) clusterOrchTemplateApiNightly() error {
+	return sh.RunV(
+		"ginkgo",
+		"-v",
+		"-r",
+		"--fail-fast",
+		"--race",
+		fmt.Sprintf("--label-filter=%s && %s", utils.ClusterOrchTemplateApiSmokeTest, utils.ClusterOrchTemplateApiTestNightly),
+		"./tests/template-api-test",
+	)
+}
+
 // Test Runs cluster orch functional test
 func (Test) clusterOrchFunctional() error {
 	return sh.RunV(

--- a/mage/test.go
+++ b/mage/test.go
@@ -129,7 +129,7 @@ func (Test) clusterOrchTemplateApiNightly() error {
 		"-r",
 		"--fail-fast",
 		"--race",
-		fmt.Sprintf("--label-filter=%s && %s", utils.ClusterOrchTemplateApiSmokeTest, utils.ClusterOrchTemplateApiTestNightly),
+		fmt.Sprintf("--label-filter=%s", utils.ClusterOrchTemplateApiTestNightly),
 		"./tests/template-api-test",
 	)
 }

--- a/tests/template-api-test/template_api_test.go
+++ b/tests/template-api-test/template_api_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Template API Tests", Ordered, func() {
 		By("Getting Default template after setting it")
 		defaultTemplateInfo, err = utils.GetDefaultTemplate(namespace)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defaultTemplateInfo.Name).To(Equal(utils.K3sTemplateOnlyName), "Default template name should match the set template name")
+		Expect(*defaultTemplateInfo.Name).To(Equal(utils.K3sTemplateOnlyName), "Default template name should match the set template name")
 		Expect(defaultTemplateInfo.Version).To(Equal(utils.K3sTemplateOnlyVersion), "Default template version should match the set template version")
 
 		By("Set the default template by providing both template name and version")
@@ -109,7 +109,7 @@ var _ = Describe("Template API Tests", Ordered, func() {
 		By("Getting Default template after setting it")
 		defaultTemplateInfo, err = utils.GetDefaultTemplate(namespace)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defaultTemplateInfo.Name).To(Equal(utils.Rke2TemplateOnlyName), "Default template name should match the set template name")
+		Expect(*defaultTemplateInfo.Name).To(Equal(utils.Rke2TemplateOnlyName), "Default template name should match the set template name")
 		Expect(defaultTemplateInfo.Version).To(Equal(utils.Rke2TemplateOnlyVersion), "Default template version should match the set template version")
 
 		By("Setting default template again after it has been set, should not error")
@@ -118,7 +118,7 @@ var _ = Describe("Template API Tests", Ordered, func() {
 		By("Getting Default template after setting it again")
 		defaultTemplateInfo, err = utils.GetDefaultTemplate(namespace)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(defaultTemplateInfo.Name).To(Equal(utils.Rke2TemplateOnlyName), "Default template name should match the set template name")
+		Expect(*defaultTemplateInfo.Name).To(Equal(utils.Rke2TemplateOnlyName), "Default template name should match the set template name")
 		Expect(defaultTemplateInfo.Version).To(Equal(utils.Rke2TemplateOnlyVersion), "Default template version should match the set template version")
 
 		By("Setting default template to a non-existing template should error")

--- a/tests/template-api-test/template_api_test.go
+++ b/tests/template-api-test/template_api_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Template API Tests", Ordered, func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should validate the template import success", Label(utils.ClusterOrchTemplateApiSmokeTest), func() {
+	It("should validate the template import success", Label(utils.ClusterOrchTemplateApiSmokeTest, utils.ClusterOrchTemplateApiTestNightly), func() {
 		By("Importing the cluster template rke2 baseline")
 		err := utils.ImportClusterTemplate(namespace, utils.TemplateTypeRke2Baseline)
 		Expect(err).NotTo(HaveOccurred())
@@ -74,7 +74,7 @@ var _ = Describe("Template API Tests", Ordered, func() {
 		}, 1*time.Minute, 2*time.Second).Should(BeTrue())
 	})
 
-	It("Should be able to retrieve a template", Label(utils.ClusterOrchTemplateApiSmokeTest), func() {
+	It("Should be able to retrieve a template", Label(utils.ClusterOrchTemplateApiSmokeTest, utils.ClusterOrchTemplateApiTestNightly), func() {
 		By("Retrieving the K3s template")
 		template, err := utils.GetClusterTemplate(namespace, utils.K3sTemplateOnlyName, utils.K3sTemplateOnlyVersion)
 		Expect(err).NotTo(HaveOccurred())
@@ -93,7 +93,7 @@ var _ = Describe("Template API Tests", Ordered, func() {
 		Expect(defaultTemplateInfo).To(BeNil(), "Default template should be nil when none has been set")
 	})
 
-	It("Should be able to set a default template", Label(utils.ClusterOrchTemplateApiSmokeTest), func() {
+	It("Should be able to set a default template", Label(utils.ClusterOrchTemplateApiSmokeTest, utils.ClusterOrchTemplateApiTestNightly), func() {
 
 		By("Set the default template by providing only template name without version")
 		err := utils.SetDefaultTemplate(namespace, utils.K3sTemplateOnlyName, "")

--- a/tests/utils/cluster_utils.go
+++ b/tests/utils/cluster_utils.go
@@ -270,7 +270,12 @@ func SetDefaultTemplate(namespace, name, version string) error {
 			return err
 		}
 	} else {
-		req, err = http.NewRequest("PUT", url, nil)
+		var defaultTemplateInfo api.DefaultTemplateInfo
+		data, err = json.Marshal(defaultTemplateInfo)
+		if err != nil {
+			return fmt.Errorf("failed to marshal default template info: %v", err)
+		}
+		req, err = http.NewRequest("PUT", url, bytes.NewBuffer(data))
 		if err != nil {
 			return err
 		}
@@ -289,7 +294,7 @@ func SetDefaultTemplate(namespace, name, version string) error {
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("failed to set default template: %s", string(body))
+		return fmt.Errorf("failed to set default template: %s, code: %v", string(body), resp.StatusCode)
 	}
 
 	return nil


### PR DESCRIPTION
### Description

Add more template api tests. Add nightly test label now.

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?
```shell
$ make bootstrap
$ make template-api-test-nightly

Running Suite: template api test suite - /home/seu/cluster-tests/tests/template-api-test
========================================================================================
Random Seed: 1748551552

Will run 6 of 6 specs
------------------------------
Template API Tests should validate the template import success [cluster-orch-template-api-smoke-test, cluster-orch-template-api-test-nightly]
/home/seu/cluster-tests/tests/template-api-test/template_api_test.go:57
  STEP: Ensuring the namespace exists @ 05/29/25 13:45:52.709
  STEP: Port forwarding to the cluster manager service @ 05/29/25 13:45:52.825
  STEP: Deleting all templates in the namespace @ 05/29/25 13:45:57.829
  STEP: Importing the cluster template rke2 baseline @ 05/29/25 13:45:57.841
  STEP: Waiting for the cluster template to be ready @ 05/29/25 13:45:57.853
  STEP: Importing the cluster template k3s baseline @ 05/29/25 13:45:58.067
  STEP: Waiting for the cluster template to be ready @ 05/29/25 13:45:58.076
• [5.570 seconds]
------------------------------
Template API Tests Should be able to retrieve a template [cluster-orch-template-api-smoke-test, cluster-orch-template-api-test-nightly]
/home/seu/cluster-tests/tests/template-api-test/template_api_test.go:77
  STEP: Retrieving the K3s template @ 05/29/25 13:45:58.28
  STEP: Retrieving the Rke2 template @ 05/29/25 13:45:58.287
• [0.011 seconds]
------------------------------
Template API Tests Should not find a default template when non has been set [cluster-orch-template-api-test-nightly]
/home/seu/cluster-tests/tests/template-api-test/template_api_test.go:89
  STEP: Getting Default template when none has been set @ 05/29/25 13:45:58.292
• [0.009 seconds]
------------------------------
Template API Tests Should be able to set a default template [cluster-orch-template-api-smoke-test, cluster-orch-template-api-test-nightly]
/home/seu/cluster-tests/tests/template-api-test/template_api_test.go:96
  STEP: Set the default template by providing only template name without version @ 05/29/25 13:45:58.301
  STEP: Getting Default template after setting it @ 05/29/25 13:45:58.319
  STEP: Set the default template by providing both template name and version @ 05/29/25 13:45:58.333
  STEP: Getting Default template after setting it @ 05/29/25 13:45:58.355
  STEP: Setting default template again after it has been set, should not error @ 05/29/25 13:45:58.365
  STEP: Getting Default template after setting it again @ 05/29/25 13:45:58.368
• [0.079 seconds]
------------------------------
Template API Tests Should error out when setting a default template with an invalid name [cluster-orch-template-api-test-nightly]
/home/seu/cluster-tests/tests/template-api-test/template_api_test.go:130
  STEP: Setting default template to a non-existing template should error @ 05/29/25 13:45:58.38
• [0.003 seconds]
------------------------------
Template API Tests Should return templates matching a filter [cluster-orch-template-api-test-nightly]
/home/seu/cluster-tests/tests/template-api-test/template_api_test.go:137
  STEP: Retrieving templates with a filter @ 05/29/25 13:45:58.384
  STEP: Deleting all templates in the namespace @ 05/29/25 13:45:58.396
Deleting template: baseline-k3s-v0.0.1
Deleting template: baseline-rke2-v0.0.1
• [0.036 seconds]
------------------------------

Ran 6 of 6 Specs in 5.712 seconds
SUCCESS! -- 6 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 6.414495851s
Test Suite Passed
```

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code