### PR TITLE
feat: configure usage of developer versions of the chart

### DIFF
--- a/.test-dependencies.yaml
+++ b/.test-dependencies.yaml
@@ -19,6 +19,7 @@
 #         package: The Helm chart package name.
 #         namespace: The Kubernetes namespace for the Helm release.
 #         version: The version of the Helm chart.
+#         use-devel: A flag to enable (or not) usage of developer versions of the chart
 #         overrides: The Helm chart overrides.
 #   - git-repo:
 #       url: The Git URL of the component's repository.
@@ -44,6 +45,7 @@ components:
         package: "edge-orch/cluster/charts/intel-infra-provider"
         namespace: "default"
         version: ""  # Use the latest version when nil
+        use-devel: false # Use development version of the chart
         overrides: "--set metrics.serviceMonitor.enabled=false --set manager.extraArgs.use-inv-stub=true
         --set southboundApi.extraArgs.useGrpcStubMiddleware=true"
       - url: "oci://registry-rs.edgeorchestration.intel.com"
@@ -51,6 +53,7 @@ components:
         package: "edge-orch/cluster/charts/intel-infra-provider-crds"
         namespace: "default"
         version: ""  # Use the latest version when nil
+        use-devel: false # Use development version of the chart
         overrides: ""
     git-repo:
       url: https://github.com/open-edge-platform/cluster-api-provider-intel.git
@@ -110,12 +113,14 @@ components:
         package: "edge-orch/cluster/charts/cluster-connect-gateway"
         namespace: "default"
         version: ""  # Use the latest version when nil
+        use-devel: false # Use development version of the chart
         overrides: "--set controller.privateCA.enabled=false"
       - url: "oci://registry-rs.edgeorchestration.intel.com"
         release-name: "cluster-connect-gateway-crd"
         package: "edge-orch/cluster/charts/cluster-connect-gateway-crd"
         namespace: "default"
         version: ""  # Use the latest version when nil
+        use-devel: false # Use development version of the chart
         overrides: ""
     git-repo:
       url: https://github.com/open-edge-platform/cluster-connect-gateway.git
@@ -145,12 +150,14 @@ components:
         package: "edge-orch/cluster/charts/cluster-manager"
         namespace: "default"
         version: ""  # Use the latest version when nil
+        use-devel: false # Use development version of the chart
         overrides: "--set clusterManager.extraArgs.disable-mt=true --set clusterManager.extraArgs.disable-auth=true --set clusterManager.extraArgs.disable-inventory=true --set templateController.extraArgs[0]='--webhook-enabled=true' --set webhookService.enabled=true"
       - url: "oci://registry-rs.edgeorchestration.intel.com"
         release-name: "cluster-template-crd"
         package: "edge-orch/cluster/charts/cluster-template-crd"
         namespace: "default"
         version: ""  # Use the latest version when nil
+        use-devel: false # Use development version of the chart
         overrides: ""
     git-repo:
       url: https://github.com/open-edge-platform/cluster-manager.git
@@ -178,6 +185,7 @@ components:
         package: ""
         namespace: ""
         version: ""
+        use-devel: false # Use development version of the chart
         overrides: ""
     git-repo:
       url: https://github.com/open-edge-platform/edge-node-agents.git

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Below is the format the `.test-dependencies.yaml` file. You can add the dependen
 #         package: The Helm chart package name.
 #         namespace: The Kubernetes namespace for the Helm release.
 #         version: The version of the Helm chart.
+#         use-devel: A flag to enable (or not) usage of developer versions of the chart
 #         overrides: The Helm chart overrides.
 #   - git-repo:
 #       url: The Git URL of the component's repository.

--- a/mage/test.go
+++ b/mage/test.go
@@ -28,6 +28,7 @@ type HelmRepo struct {
 	Package     string `yaml:"package" json:"package"`
 	Namespace   string `yaml:"namespace" json:"namespace"`
 	Version     string `yaml:"version" json:"version"`
+	UseDevel    bool   `yaml:"use-devel" json:"use-devel"`
 	Overrides   string `yaml:"overrides" json:"overrides"`
 }
 
@@ -265,9 +266,12 @@ func processComponent(component Component) error {
 	if component.SkipLocalBuild {
 		for _, helm := range component.HelmRepo {
 			chart := fmt.Sprintf("%s/%s", helm.URL, helm.Package)
-			cmd := fmt.Sprintf("helm install %s %s --namespace %s --devel", helm.ReleaseName, chart, helm.Namespace)
+			cmd := fmt.Sprintf("helm install %s %s --namespace %s", helm.ReleaseName, chart, helm.Namespace)
 			if helm.Version != "" {
 				cmd = fmt.Sprintf("%s --version %s", cmd, helm.Version)
+			}
+			if helm.UseDevel {
+				cmd = fmt.Sprintf("%s --devel", cmd)
 			}
 			if helm.Overrides != "" {
 				cmd = fmt.Sprintf("%s %s", cmd, helm.Overrides)


### PR DESCRIPTION
### Description

Configure usage of developer versions of the chart. By default developer versions of charts are not installed. However if users want, they can override this flag on a per component level and use latest developer charts if needed.

Fixes # (issue)

### Any Newly Introduced Dependencies

None

### How Has This Been Tested?

CI

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code