### PR TITLE
chore: bump capi-k3s v0.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ PROXY_ENV_FILE ?= $(HOME)/.config/cluster-tests/proxy.env
 CLUSTERCTL_VERSION = v1.11.5
 
 CAPI_K3S_FORK_REPO_URL ?=
-CAPI_K3S_VERSION ?= v0.3.1
+CAPI_K3S_VERSION ?= v0.4.0
 CAPI_OPERATOR_HELM_VERSION ?= 0.24.0
 
 # Providers versions/URLs as needed


### PR DESCRIPTION
### Description

bump capi-k3s to v0.4.0

Fixes # (issue)
ITEP-88953


### Any Newly Introduced Dependencies
no

### How Has This Been Tested?

CI:

```
capk-system            capi-k3s-bootstrap-controller-manager       1/1     1            1           2m56s   manager                           ghcr.io/k3s-io/cluster-api-k3s/bootstrap-controller:v0.4.0                                                   cluster.x-k8s.io/provider=bootstrap-k3s,control-plane=controller-manager
capk-system            capi-k3s-control-plane-controller-manager   1/1     1            1           2m56s   manager                           ghcr.io/k3s-io/cluster-api-k3s/controlplane-controller:v0.4.0        
```

### Checklist:

- [x] I agree to use the APACHE-2.0 license for my code changes
- [x] I have not introduced any 3rd party dependency changes
- [x] I have performed a self-review of my code