### PR TITLE
Enable post-merge security scans for tag creation

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -10,6 +10,8 @@ on:
     branches:
       - main
       - release-*
+    tags:
+      - '*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The change ensures that the workflow will also run on any tag push, in addition to pushes to the `main` and `release-*` branches.

* [`.github/workflows/post-merge.yml`](diffhunk://#diff-649dadd84b5d9938ac7f7a33a4020062fa437edcfc320554adf8bcf62c14602aR13-R14): Updated the workflow trigger to include all tag pushes by adding a `tags` pattern under `on.push`.